### PR TITLE
Update aws-cdk libraries

### DIFF
--- a/lib/first-cdk-app-stack.ts
+++ b/lib/first-cdk-app-stack.ts
@@ -20,6 +20,7 @@ export class FirstCdkAppStack extends Stack {
 
     //define lambda function and regeference function file
     const lambda_backend = new NodejsFunction(this, "function", {
+      runtime: lambda.Runtime.NODEJS_20_X,
       tracing: lambda.Tracing.ACTIVE,
       environment: {
         DYNAMODB: dynamodb_table.tableName

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/jest": "^27.5.2",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
-    "aws-cdk": "2.39.1",
+    "aws-cdk": "2.139.1",
     "aws-sdk": "^2.1218.0",
     "aws-xray-sdk": "^3.3.7",
     "jest": "^27.5.1",
@@ -24,7 +24,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.39.1",
+    "aws-cdk-lib": "2.139.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
When we run $ cdk deploy blue we get the below response from AWS

CREATE_FAILED        | AWS::Lambda::Function       | functionF19B1A04
Resource handler returned message: "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the n
ew runtime (nodejs20.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 9f3b66f8-56ad-4ebe-a84a-0bb260e03e4b)" (RequestToken: cedd
8f0c-02a4-dfba-cfb4-eab72c2904da, HandlerErrorCode: InvalidRequest)

To fix this we need to upgrade the aws-cdk-lib version.